### PR TITLE
Add HipChat support [ LABS-216 ]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,3 @@ services:
 before_script:
   - psql -c 'create database perf_alert_test;' -U postgres
   - bundle exec rails db:migrate
-env:
-  - SLACK_WEBHOOK_URL='https://www.example.com'

--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,14 @@ gem 'active_model_serializers'
 gem 'sidekiq'
 gem 'slack-notifier'
 gem 'swagger_client', path: 'vendor/zoompf'
+gem 'httparty'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   gem 'rspec-rails'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,11 +50,14 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (7.0.0)
     builder (3.2.2)
     byebug (9.0.5)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     ethon (0.9.0)
@@ -62,6 +65,9 @@ GEM
     ffi (1.9.10)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     json (1.8.3)
     jsonapi (0.1.1.beta2)
@@ -79,6 +85,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    multi_xml (0.5.5)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -134,6 +141,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
     sidekiq (4.1.2)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -156,6 +164,11 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    vcr (3.0.3)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -166,6 +179,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   byebug
+  httparty
   listen (~> 3.0.5)
   pg
   puma (~> 3.0)
@@ -177,6 +191,8 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   swagger_client!
   tzinfo-data
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ OPTIMIZATION_TEST_ID
 
 # Slack webhook URL to notify when a snapshot is triggered
 SLACK_WEBHOOK_URL
+
+# Your HipChat Room ID
+HIPCHAT_ROOM_ID
+
+# Your HipChat API key
+HIPCHAT_API_KEY
 ```
 * Set up your CI's post deploy webhook endpoint to the url of your app (e.g https://your-app.herokuapp.com)
 
@@ -52,7 +58,10 @@ Right now, PerfAlert only supports webhooks sent from Semaphore CI. We plan to a
 
 ### Notifications
 
-Right now, PerfAlert only supports Slack notifications. We plan to add support for more messaging services.
+Right now, PerfAlert only supports Slack and HipChat notifications. We plan to add support for more messaging services.
 
 If you wish to change what information is sent to Slack or how it is presented, you will need to change the `slack_worker.rb`
 file located in the `app/workers` directory. More information on how to configure the payload sent to Slack can be found [here](https://api.slack.com/incoming-webhooks).
+
+Similarly, you can change how your HipChat notification looks by editing the `hip_chat_worker.rb` file located in the `app/workers` directory. Please refer to the
+[HipChat API docs](https://www.hipchat.com/docs/apiv2/method/send_room_notification) for more information.

--- a/app/concerns/commit_formatter.rb
+++ b/app/concerns/commit_formatter.rb
@@ -1,0 +1,10 @@
+module CommitFormatter
+  def format_commit(commit)
+    commit['id'] = format_commit_id commit['id']
+    commit
+  end
+
+  def format_commit_id(id)
+    id[0..6] if id
+  end
+end

--- a/app/helpers/color_helper.rb
+++ b/app/helpers/color_helper.rb
@@ -1,0 +1,11 @@
+module ColorHelper
+  module Success
+    SIMPLE = 'green'.freeze
+    HEX = '#2ECC71'.freeze
+  end
+
+  module Failure
+    SIMPLE = 'red'.freeze
+    HEX = '#C0392B'.freeze
+  end
+end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -1,8 +1,9 @@
 class Scan < ApplicationRecord
+  include CommitFormatter
   validates_with ScanValidator
   after_save :perform
 
   def perform
-    OptimizationWorker.perform_async(commit)
+    OptimizationWorker.perform_async(format_commit(commit))
   end
 end

--- a/app/notifiers/hip_chat_notifier.rb
+++ b/app/notifiers/hip_chat_notifier.rb
@@ -1,0 +1,79 @@
+class HipChatNotifier
+  ATTRIBUTES = %I(commit_info score_result color comparison_url)
+
+  attr_reader(*ATTRIBUTES)
+
+  DEFAULTS = {
+    commit_info: {
+      'id' => 'No commit ID given',
+      'url' => 'https://github.com/Rigor/PerfAlert/blob/master/README.md',
+      'author_name' => 'No author given'
+    },
+    score_result: 'No score result given',
+    color: 'red',
+    comparison_url: 'https://github.com/Rigor/PerfAlert/blob/master/README.md'
+  }
+
+  def initialize(opts = {})
+    DEFAULTS.
+      merge(opts).
+      slice(*ATTRIBUTES).
+      each { |k,v| instance_variable_set("@#{k}", v) }
+  end
+
+  def send
+    HTTParty.post(url,
+                  body: {
+                    message:  score_result,
+                    card:     create_card,
+                    color:    color
+                  }.to_json,
+                  headers: headers)
+  end
+
+  private
+
+  def create_card
+    icon_url ? card.merge(icon: { url: icon_url }, id: generate_id(card)) : card.merge(id: generate_id(card))
+  end
+
+  def card
+    {
+      'style'  => 'application',
+      'format' => 'compact',
+      'url'    => comparison_url,
+      'title'  => score_result,
+      'attributes' => [
+        {
+          'label' => 'commit',
+          'value' => {
+            'label' => commit_info['id'],
+            'url'   => commit_info['url']
+          }
+        },
+        {
+          'label' => 'Author',
+          'value' => {
+            'label' => commit_info['author_name']
+          }
+        }
+      ],
+    }
+  end
+
+  def url
+    "https://www.hipchat.com/v2/room/#{ENV['HIPCHAT_ROOM_ID']}/notification?auth_token=#{ENV['HIPCHAT_API_KEY']}"
+  end
+
+  def generate_id(obj)
+    Digest::MD5.hexdigest(obj.inspect)
+  end
+
+  def icon_url
+    ENV['ICON_URL']
+  end
+
+  def headers
+    {'Content-Type' => 'application/json'}
+  end
+end

--- a/app/notifiers/slack_notifier.rb
+++ b/app/notifiers/slack_notifier.rb
@@ -1,0 +1,52 @@
+class SlackNotifier
+  ATTRIBUTES = %I(commit_info score_result color comparison_url)
+
+  attr_reader(*ATTRIBUTES)
+
+  DEFAULTS = {
+    commit_info: {
+      'id' => 'No commit ID given',
+      'url' => 'https://github.com/Rigor/PerfAlert/blob/master/README.md',
+      'author_name' => 'No author given'
+    },
+    score_result: 'No score result given',
+    color: '#C0392B',
+    comparison_url: 'https://github.com/Rigor/PerfAlert/blob/master/README.md'
+  }
+
+  
+  def initialize(opts = {})
+    DEFAULTS.
+      merge(opts).
+      slice(*ATTRIBUTES).
+      each { |k,v| instance_variable_set("@#{k}", v) }
+
+    @client = Slack::Notifier.new(ENV['SLACK_WEBHOOK_URL'], http_options: { open_timeout: 10 }).
+              tap { |notifier| notifier.username = 'Rigor Optimization' }
+  end
+
+  def send
+    @client.ping(nil, attachments: [ attachments ])
+  end
+
+  def attachments
+    {
+      title:      score_result,
+      title_link: comparison_url,
+      color:      color,
+      fields: [
+        {
+          title: 'Commit',
+          value: "<#{commit_info['url']} | #{commit_info['id'][0..6]}>",
+          short: true
+        },
+        {
+          title: 'Author',
+          value: commit_info['author_name'],
+          short: true
+        }
+      ],
+      fallback: "#{score_result}: #{comparison_url}"
+    }
+  end
+end

--- a/app/validators/scan_validator.rb
+++ b/app/validators/scan_validator.rb
@@ -7,13 +7,5 @@ class ScanValidator < ActiveModel::Validator
     if record.result != 'passed'
       record.errors[:result] << 'Failed CI build. Aborting.'
     end
-
-    # if !!server_regex && !server_regex.match(record.server_name)
-    #   record.errors[:server_name] << "Server #{record.server_name} doesn't match regex. Quitting."
-    # end
   end
-
-  # def server_regex
-  #   Rails.application.config.server_regex
-  # end
 end

--- a/app/workers/hip_chat_worker.rb
+++ b/app/workers/hip_chat_worker.rb
@@ -1,0 +1,14 @@
+class HipChatWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: false
+
+  def perform commit_info, score_result, color, comparison_url
+    HipChatNotifier.new({
+                          commit_info: commit_info,
+                          score_result: score_result,
+                          color: color,
+                          comparison_url: comparison_url
+                        }).send
+  end
+end

--- a/app/workers/optimization_worker.rb
+++ b/app/workers/optimization_worker.rb
@@ -42,14 +42,15 @@ class OptimizationWorker
 
     comparison_url   = optimization_compare_url(old_snapshot.snapshot_id, new_snapshot.snapshot_id)
 
-    defect_count_result, color = if new_defect_count > old_defect_count
-      ["Total defect count increased from #{old_defect_count} to #{new_defect_count}", '#C0392B']
+    defect_count_result, result = if new_defect_count > old_defect_count
+      ["Total defect count increased from #{old_defect_count} to #{new_defect_count}", 'Failure']
     elsif new_defect_count < old_defect_count
-      ["Total defect count decreased from #{old_defect_count} to #{new_defect_count}", '#2ECC71']
+      ["Total defect count decreased from #{old_defect_count} to #{new_defect_count}", 'Success']
     else
-      ["Total defect count remained the same", '#2ECC71']
+      ["Total defect count remained the same", 'Success']
     end
-    SlackWorker.perform_async(commit_info, defect_count_result, color, comparison_url)
+    SlackWorker.perform_async(commit_info, defect_count_result, "ColorHelper::#{result}::HEX".constantize, comparison_url)
+    HipChatWorker.perform_async(commit_info, defect_count_result, "ColorHelper::#{result}::SIMPLE".constantize, comparison_url)
   end
 
   private
@@ -57,9 +58,4 @@ class OptimizationWorker
   def optimization_compare_url old_snapshot, new_snapshot
     "https://optimization.rigor.com/c/#{old_snapshot}/#{new_snapshot}"
   end
-
-  # def api_client
-  #   @api_client ||= SwaggerClient::SnapshotsApi.new(SwaggerClient::ApiClient.new(ENV['ZOOMPF_API_KEY']))
-  # end
-
 end

--- a/app/workers/slack_worker.rb
+++ b/app/workers/slack_worker.rb
@@ -1,33 +1,13 @@
 class SlackWorker
   include Sidekiq::Worker
-  SLACK_NOTIFIER = Slack::Notifier.new(ENV['SLACK_WEBHOOK_URL'], http_options: { open_timeout: 10 })
-  SLACK_NOTIFIER.username = 'Rigor Optimization'
 
   def perform commit_info, score_result, color, comparison_url
-    commit_id     = commit_info['id']
-    commit_url    = commit_info['url']
-    commit_author = commit_info['author_name']
-
-    SLACK_NOTIFIER.ping(nil, attachments: [
-      {
-        title:      score_result,
-        title_link: comparison_url,
-        color:      color,
-        fields: [
-          {
-            title: 'Commit',
-            value: "<#{commit_url}|#{commit_id[0..6]}>",
-            short: true
-          },
-          {
-            title: 'Author',
-            value: commit_author,
-            short: true
-          }
-        ],
-        fallback: "#{score_result}: #{comparison_url}"
-      }
-    ])
+    SlackNotifier.new({
+                          commit_info:    commit_info,
+                          score_result:   score_result,
+                          color:          color,
+                          comparison_url: comparison_url
+                       }).send
   end
 
 end

--- a/spec/notifiers/hip_chat_notifier_spec.rb
+++ b/spec/notifiers/hip_chat_notifier_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe HipChatNotifier do
+  describe '#send' do
+    let(:messenger) { HipChatNotifier.new(NotifierPayloads::HIPCHAT) }
+
+    it 'successfully POSTs to HipChat', :vcr do
+      response = messenger.send
+      expect(response.body).to be_nil
+      expect(response.code).to eql(204)
+    end
+  end
+end

--- a/spec/notifiers/slack_notifier_spec.rb
+++ b/spec/notifiers/slack_notifier_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe SlackNotifier do
+  describe '#send' do
+    let(:messenger) { SlackNotifier.new(NotifierPayloads::SLACK) }
+
+    it 'successfully POSTs to Slack', :vcr do
+      response = messenger.send
+      expect(response.body).to eql('ok')
+      expect(response.code).to eql('200')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,11 @@
 
 require_relative '../config/environment'
 require 'sidekiq/testing'
+require 'webmock/rspec'
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
+
+# disallow HTTP requests to hit enpoints. Stub them with Webmock
+WebMock.disable_net_connect!(allow_localhost: true)
 
 # This tells Sidekiq to put jobs into an array for inspection during testing rather than a queue
 Sidekiq::Testing.fake!

--- a/spec/support/notifier_payload.rb
+++ b/spec/support/notifier_payload.rb
@@ -1,0 +1,18 @@
+module NotifierPayloads
+  # This constant is used in messenger tests. It is a sample payload that is sent to each messenger for parsing.
+  BASE = {
+    commit_info: {
+      'id'  => 'a0d514e1e6c8320d79576aa2ea8c8ecc040da701',
+      'url' => 'https://github.com/Rigor/labs/commit/a0d514e1e6c8320d79576aa2ea8c8ecc040da701',
+      'author_name' => 'Test User',
+      'author_email' => 'test.user@rigor.com',
+      'message' => 'wefv',
+      'timestamp' => '2016-08-01T21:54:33Z'
+    },
+    score_result: 'Total defect count remained the same',
+    comparison_url: 'https://optimization.rigor.com/c/224148/224148'
+  }.freeze
+
+  HIPCHAT = BASE.merge color: 'green'
+  SLACK   = BASE.merge color: '#2ECC71'
+end

--- a/spec/support/vcr/HipChatMessenger/_send/successfully_POSTs_to_HipChat.yml
+++ b/spec/support/vcr/HipChatMessenger/_send/successfully_POSTs_to_HipChat.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.hipchat.com/v2/room/2984707/notification?auth_token=UXKQxzkCMq3Ngv3AjeOIMY94ljzgGzbpqf1eyFoq
+    body:
+      encoding: UTF-8
+      string: '{"message":"Total defect count remained the same","card":{"style":"application","format":"compact","url":"https://optimization.rigor.com/c/224148/224148","title":"Total
+        defect count remained the same","icon":{"url":"http://rigor.com/favicon-96x96.png"},"attributes":[{"label":"commit","value":{"label":"a0d514e","url":"https://github.com/Rigor/labs/commit/a0d514e1e6c8320d79576aa2ea8c8ecc040da701"}},{"label":"Author","value":{"label":"Test
+        User"}}],"id":"739856"},"color":"green"}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-Backoff
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - text/html
+      Date:
+      - Wed, 03 Aug 2016 19:34:03 GMT
+      Location:
+      - https://api.hipchat.com/v2/room/2984707/history/ff4e63d4-fb14-4bbe-bb55-d56fbd0cbbd8
+      Server:
+      - nginx
+      Set-Cookie:
+      - AWSELB=F5A931F70283101795B7345DC34900751EE8E84836B8D59FF717D82C5ABD9ACED7A14BAD6E8272107B0508ABBFC953CCB355DBD727B91D1F9D7C6AA7066C7FEB5F42D6D68E;PATH=/
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1470253144'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 19:34:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/HipChatNotifier/_send/successfully_POSTs_to_HipChat.yml
+++ b/spec/support/vcr/HipChatNotifier/_send/successfully_POSTs_to_HipChat.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.hipchat.com/v2/room/2984707/notification?auth_token=UXKQxzkCMq3Ngv3AjeOIMY94ljzgGzbpqf1eyFoq
+    body:
+      encoding: UTF-8
+      string: '{"message":"Total defect count remained the same","card":{"style":"application","format":"compact","url":"https://optimization.rigor.com/c/224148/224148","title":"Total
+        defect count remained the same","attributes":[{"label":"commit","value":{"label":"a0d514e","url":"https://github.com/Rigor/labs/commit/a0d514e1e6c8320d79576aa2ea8c8ecc040da701"}},{"label":"Author","value":{"label":"Test
+        User"}}],"id":"717228"},"color":"green"}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-Backoff
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 04 Aug 2016 17:57:42 GMT
+      Location:
+      - https://api.hipchat.com/v2/room/2984707/history/8452e80a-5cf8-4a37-a061-01d1bc592f79
+      Server:
+      - nginx
+      Set-Cookie:
+      - AWSELB=F5A931F70283101795B7345DC34900751EE8E84836B8D59FF717D82C5ABD9ACED7A14BAD6E86F7A7EB66862D07B9B0E070718534541973C2310A5234FA5C2CC14D75D84000;PATH=/
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1470333763'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 17:57:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/SlackMessenger/_perform/successfully_POSTs_to_Slack.yml
+++ b/spec/support/vcr/SlackMessenger/_perform/successfully_POSTs_to_Slack.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://hooks.slack.com/services/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
+    body:
+      encoding: US-ASCII
+      string: payload=%7B%22username%22%3A%22Rigor+Optimization%22%2C%22attachments%22%3A%5B%7B%22title%22%3A%22Total+defect+count+remained+the+same%22%2C%22title_link%22%3A%22https%3A%2F%2Foptimization.rigor.com%2Fc%2F224148%2F224148%22%2C%22color%22%3A%22%232ECC71%22%2C%22fields%22%3A%5B%7B%22title%22%3A%22Commit%22%2C%22value%22%3A%22%5Cu003chttps%3A%2F%2Fgithub.com%2FRigor%2Flabs%2Fcommit%2Fa0d514e1e6c8320d79576aa2ea8c8ecc040da701%7Ca0d514e%5Cu003e%22%2C%22short%22%3Atrue%7D%2C%7B%22title%22%3A%22Author%22%2C%22value%22%3A%22Test+User%22%2C%22short%22%3Atrue%7D%5D%2C%22fallback%22%3A%22Total+defect+count+remained+the+same%3A+https%3A%2F%2Foptimization.rigor.com%2Fc%2F224148%2F224148%22%7D%5D%7D
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - referrer no-referrer;
+      Date:
+      - Wed, 03 Aug 2016 19:13:18 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Slack-Backend:
+      - z
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e9805f6e7e7fc960be065e8aee90e3c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _ja1qYhZQxp9r4FviFA8geE6C2N2fEc8K2nPTSNWstM9IldYtYCB8Q==
+    body:
+      encoding: ASCII-8BIT
+      string: ok
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 19:13:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/SlackNotifier/_perform/successfully_POSTs_to_Slack.yml
+++ b/spec/support/vcr/SlackNotifier/_perform/successfully_POSTs_to_Slack.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://hooks.slack.com/services/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
+    body:
+      encoding: US-ASCII
+      string: payload=%7B%22username%22%3A%22Rigor+Optimization%22%2C%22attachments%22%3A%5B%7B%22title%22%3A%22Total+defect+count+remained+the+same%22%2C%22title_link%22%3A%22https%3A%2F%2Foptimization.rigor.com%2Fc%2F224148%2F224148%22%2C%22color%22%3A%22%232ECC71%22%2C%22fields%22%3A%5B%7B%22title%22%3A%22Commit%22%2C%22value%22%3A%22%5Cu003chttps%3A%2F%2Fgithub.com%2FRigor%2Flabs%2Fcommit%2Fa0d514e1e6c8320d79576aa2ea8c8ecc040da701+%7C+a0d514e%5Cu003e%22%2C%22short%22%3Atrue%7D%2C%7B%22title%22%3A%22Author%22%2C%22value%22%3A%22Test+User%22%2C%22short%22%3Atrue%7D%5D%2C%22fallback%22%3A%22Total+defect+count+remained+the+same%3A+https%3A%2F%2Foptimization.rigor.com%2Fc%2F224148%2F224148%22%7D%5D%7D
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - referrer no-referrer;
+      Date:
+      - Thu, 04 Aug 2016 17:57:42 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Slack-Backend:
+      - z
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 326449c08c10f9b31da3d6e578388005.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0uel4ZedO6OdBkf-jyXayQDxsftdAPzPWx4CFm2r7psi8Zk4sXT1VA==
+    body:
+      encoding: ASCII-8BIT
+      string: ok
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 17:57:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/SlackNotifier/_send/successfully_POSTs_to_Slack.yml
+++ b/spec/support/vcr/SlackNotifier/_send/successfully_POSTs_to_Slack.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://hooks.slack.com/services/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
+    body:
+      encoding: US-ASCII
+      string: payload=%7B%22username%22%3A%22Rigor+Optimization%22%2C%22attachments%22%3A%5B%7B%22title%22%3A%22Total+defect+count+remained+the+same%22%2C%22title_link%22%3A%22https%3A%2F%2Foptimization.rigor.com%2Fc%2F224148%2F224148%22%2C%22color%22%3A%22%232ECC71%22%2C%22fields%22%3A%5B%7B%22title%22%3A%22Commit%22%2C%22value%22%3A%22%5Cu003chttps%3A%2F%2Fgithub.com%2FRigor%2Flabs%2Fcommit%2Fa0d514e1e6c8320d79576aa2ea8c8ecc040da701+%7C+a0d514e%5Cu003e%22%2C%22short%22%3Atrue%7D%2C%7B%22title%22%3A%22Author%22%2C%22value%22%3A%22Test+User%22%2C%22short%22%3Atrue%7D%5D%2C%22fallback%22%3A%22Total+defect+count+remained+the+same%3A+https%3A%2F%2Foptimization.rigor.com%2Fc%2F224148%2F224148%22%7D%5D%7D
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - referrer no-referrer;
+      Date:
+      - Wed, 10 Aug 2016 19:16:36 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Slack-Backend:
+      - z
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9f21952d33d91266890f2ab34b849a9d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bOAcQ3DZUhBnSHuB3Zkuq5EyptauIitjKkLkBwPCAT5d1MC-iaT3mw==
+    body:
+      encoding: ASCII-8BIT
+      string: ok
+    http_version: 
+  recorded_at: Wed, 10 Aug 2016 19:16:36 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -1,0 +1,9 @@
+require 'vcr'
+
+# vcr configuration. vcr is used to replay HTTP repsonses as a way of stubbing requests. This is used
+# in tandem with webmock to ensure that any external API testing is contained locally with stored reponses
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/support/vcr'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end


### PR DESCRIPTION
I refactored the API calling logic in `slack_worker.rb` out into a PORO and created a HipChat messenger in the same manner. This provides a good setup for generalizing messengers in a future PR. `vcr` and `webmocks` were added for testing messengers so that testing is completely local. 

HipChat messages look like this:

![screen shot 2016-08-03 at 4 09 19 pm](https://cloud.githubusercontent.com/assets/9884408/17380339/b7a03ee8-5994-11e6-9cfb-f2ca84f8801b.png)


Notes:

- I wasn't sure whether to name the messengers as `messenger` or `notifier`. I think it's a trivial choice, but I would like some feedback as to the pros and cons of each. If it's agreed that it is trivial, I'll leave them as is.

- There's a need to refactor how colors are handled for each messenger. Since the messengers are primed to be generalized, I've left graceful assignment of colors to be handled in that PR.