### PR TITLE
Add basic authentication [ LABS-223 ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ the total number of defects it has by leveraging Rigor Optimization scans.
 * Deploy the app to Heroku with the deploy button above or the host of your choice.
 * Set the environment variables:
 ```
+# Username you want for authentication
+PERFUSER
+
+# Password you want for authentication
+PERFPASS
+
 # API key for your Rigor Optimization account
 OPTIMIZATION_API_KEY
 
@@ -28,7 +34,7 @@ HIPCHAT_ROOM_ID
 # Your HipChat API key
 HIPCHAT_API_KEY
 ```
-* Set up your CI's post deploy webhook endpoint to the url of your app (e.g https://your-app.herokuapp.com)
+* Set up your CI's post deploy webhook endpoint to the url of your app (e.g https://PERFUSER:PERFPASS@your-app.herokuapp.com)
 
 ## Dependencies
 

--- a/app/concerns/commit_formatter.rb
+++ b/app/concerns/commit_formatter.rb
@@ -1,7 +1,6 @@
 module CommitFormatter
   def format_commit(commit)
-    commit['id'] = format_commit_id commit['id']
-    commit
+    commit.tap { |c| c['id'] = format_commit_id(c['id']) if c }
   end
 
   def format_commit_id(id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include ActionController::HttpAuthentication::Basic::ControllerMethods
 end

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -1,4 +1,5 @@
 class ScansController < ApplicationController
+  http_basic_authenticate_with name: ENV['PERFUSER'], password: ENV['PERFPASS']
   before_action :set_scan, only: [:show, :update, :destroy]
 
   # GET /scans

--- a/spec/controller/scan_controller_spec.rb
+++ b/spec/controller/scan_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ScansController do
+  describe 'POST', type: :request do
+    let(:payload) {{ 'result': 'passed', 'event': 'deploy', 'commit': { } }}
+
+    context 'without credentials' do
+      it 'does not authenticate' do
+        post '/', scan: payload
+        expect(last_response.status).to eql(401)
+      end
+    end
+
+    context 'with credentials' do
+      it 'creates a new scan' do
+        http_login
+        post '/', scan: payload
+        expect(last_response.status).to eql(201)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 # disallow HTTP requests to hit enpoints. Stub them with Webmock
 WebMock.disable_net_connect!(allow_localhost: true)
 
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
+
 # This tells Sidekiq to put jobs into an array for inspection during testing rather than a queue
 Sidekiq::Testing.fake!
 
@@ -63,6 +65,11 @@ RSpec.configure do |config|
   config.before(:each) do
     Sidekiq::Worker.clear_all
   end
+
+  # include authentication helpers for request specs
+  config.include AuthHelper, type: :request
+  # include Rack::Test::Methods for simplifying request specs
+  config.include RequestHelper, type: :request
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,0 +1,7 @@
+module AuthHelper
+  def http_login
+    user = ENV['PERFUSER']
+    pass = ENV['PERFPASS']
+    header 'Authorization', ActionController::HttpAuthentication::Basic.encode_credentials(user, pass)
+  end
+end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,7 @@
+module RequestHelper
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+end


### PR DESCRIPTION
I think this is pretty straightforward. Basic authentication requires an authentication header that is base64 encoded. This should be upgraded to a better security posture in the future, but it should suffice for now.